### PR TITLE
feat: recursively merge file and group level values

### DIFF
--- a/cmd/action/main.go
+++ b/cmd/action/main.go
@@ -330,6 +330,7 @@ func processRepository(repo Repository, globalGroups map[string][]FileStructure,
 }
 
 // mergeValues merges group-level values with file-level.
+// For slices and non-map values, the value from src will overwrite the one in dst.
 func mergeValuesRecursively(dst, src map[string]interface{}) map[string]interface{} {
 	for key, srcVal := range src {
 		if dstVal, ok := dst[key]; ok {
@@ -337,13 +338,6 @@ func mergeValuesRecursively(dst, src map[string]interface{}) map[string]interfac
 			if srcMap, srcOk := srcVal.(map[string]interface{}); srcOk {
 				if dstMap, dstOk := dstVal.(map[string]interface{}); dstOk {
 					dst[key] = mergeValuesRecursively(dstMap, srcMap)
-					continue
-				}
-			}
-			// If both values are slices, append them
-			if srcSlice, srcOk := srcVal.([]interface{}); srcOk {
-				if dstSlice, dstOk := dstVal.([]interface{}); dstOk {
-					dst[key] = append(dstSlice, srcSlice...)
 					continue
 				}
 			}

--- a/cmd/action/main.go
+++ b/cmd/action/main.go
@@ -333,23 +333,23 @@ func processRepository(repo Repository, globalGroups map[string][]FileStructure,
 func mergeValuesRecursively(dst, src map[string]interface{}) map[string]interface{} {
 	for key, srcVal := range src {
 		if dstVal, ok := dst[key]; ok {
-			// If the key exists in both maps
+			// If both values are maps, merge them recursively
 			if srcMap, srcOk := srcVal.(map[string]interface{}); srcOk {
 				if dstMap, dstOk := dstVal.(map[string]interface{}); dstOk {
-					// If both values are maps, merge them recursively
 					dst[key] = mergeValuesRecursively(dstMap, srcMap)
-				} else {
-					// If the value in the source is a map but not in the destination, replace it
-					dst[key] = srcVal
+					continue
 				}
-			} else {
-				// If the source value is not a map, replace the destination value
-				dst[key] = srcVal
 			}
-		} else {
-			// If the key doesn't exist in the destination, add it
-			dst[key] = srcVal
+			// If both values are slices, append them
+			if srcSlice, srcOk := srcVal.([]interface{}); srcOk {
+				if dstSlice, dstOk := dstVal.([]interface{}); dstOk {
+					dst[key] = append(dstSlice, srcSlice...)
+					continue
+				}
+			}
 		}
+		// For all other cases, or if the key doesn't exist in dst, set/overwrite the dst value
+		dst[key] = srcVal
 	}
 	return dst
 }

--- a/cmd/action/main.go
+++ b/cmd/action/main.go
@@ -315,7 +315,7 @@ func processRepository(repo Repository, globalGroups map[string][]FileStructure,
 		for i, file := range group {
 			template.Files[i] = file
 			// Merge group-level values with file-level values
-			mergedValues := mergeValuesRecursively(file.Values, groupRef.Values)
+			mergedValues := mergeValues(file.Values, groupRef.Values)
 
 			template.Files[i].Values = mergedValues
 		}
@@ -331,13 +331,13 @@ func processRepository(repo Repository, globalGroups map[string][]FileStructure,
 
 // mergeValues merges group-level values with file-level.
 // For slices and non-map values, the value from src will overwrite the one in dst.
-func mergeValuesRecursively(dst, src map[string]interface{}) map[string]interface{} {
+func mergeValues(dst, src map[string]interface{}) map[string]interface{} {
 	for key, srcVal := range src {
 		if dstVal, ok := dst[key]; ok {
 			// If both values are maps, merge them recursively
 			if srcMap, srcOk := srcVal.(map[string]interface{}); srcOk {
 				if dstMap, dstOk := dstVal.(map[string]interface{}); dstOk {
-					dst[key] = mergeValuesRecursively(dstMap, srcMap)
+					dst[key] = mergeValues(dstMap, srcMap)
 					continue
 				}
 			}

--- a/cmd/action/main_test.go
+++ b/cmd/action/main_test.go
@@ -544,7 +544,7 @@ func TestMergeValuesRecursively(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := mergeValuesRecursively(tt.dst, tt.src)
+			result := mergeValues(tt.dst, tt.src)
 			if !reflect.DeepEqual(result, tt.expected) {
 				t.Errorf("mergeValuesRecursively() = %v, want %v", result, tt.expected)
 			}

--- a/cmd/action/main_test.go
+++ b/cmd/action/main_test.go
@@ -522,7 +522,7 @@ func TestMergeValuesRecursively(t *testing.T) {
 					},
 				},
 				"level1b": []interface{}{
-					map[string]interface{}{"arrayKey1": "arrayValue1Modified"},
+					map[string]interface{}{"arrayKey1": "arrayValue1"},
 					"arrayItem2",
 					"arrayItem3",
 				},

--- a/cmd/action/main_test.go
+++ b/cmd/action/main_test.go
@@ -479,17 +479,22 @@ func TestMergeValuesRecursively(t *testing.T) {
 			},
 		},
 		{
-			name: "Complex nested structure with arrays and maps",
+			name: "Complex nested structure with maps and slices",
 			dst: map[string]interface{}{
 				"level1": map[string]interface{}{
 					"level2a": map[string]interface{}{
-						"key1": "original1",
+						"key1": "old1",
 						"key2": []interface{}{"item1", "item2"},
+						"key3": "old3",
 					},
-					"level2b": "value2b",
+					"level2b": map[string]interface{}{
+						"nestedInLevel2b": "oldValue",
+					},
 				},
 				"level1b": []interface{}{
-					map[string]interface{}{"arrayKey1": "arrayValue1"},
+					map[string]interface{}{
+						"arrayKey1": "arrayValue1",
+					},
 					"arrayItem2",
 				},
 			},
@@ -497,15 +502,20 @@ func TestMergeValuesRecursively(t *testing.T) {
 				"level1": map[string]interface{}{
 					"level2a": map[string]interface{}{
 						"key1": "new1",
-						"key3": "new3",
+						// key2 is a slice, should overwrite
 						"key2": []interface{}{"item3"},
+						"key3": "new3",
 					},
+					// level2b is a map, should merge
 					"level2b": map[string]interface{}{
 						"nestedInLevel2b": "newValue",
 					},
 				},
+				// level1b is a slice, should overwrite
 				"level1b": []interface{}{
-					map[string]interface{}{"arrayKey1": "arrayValue1Modified"},
+					map[string]interface{}{
+						"arrayKey1": "arrayValue1Modified",
+					},
 					"arrayItem3",
 				},
 				"newTopLevel": "newTopValue",
@@ -514,7 +524,7 @@ func TestMergeValuesRecursively(t *testing.T) {
 				"level1": map[string]interface{}{
 					"level2a": map[string]interface{}{
 						"key1": "new1",
-						"key2": []interface{}{"item1", "item2", "item3"},
+						"key2": []interface{}{"item3"}, // src slice overwrites dst slice
 						"key3": "new3",
 					},
 					"level2b": map[string]interface{}{
@@ -522,9 +532,10 @@ func TestMergeValuesRecursively(t *testing.T) {
 					},
 				},
 				"level1b": []interface{}{
-					map[string]interface{}{"arrayKey1": "arrayValue1"},
-					"arrayItem2",
-					"arrayItem3",
+					map[string]interface{}{
+						"arrayKey1": "arrayValue1Modified",
+					},
+					"arrayItem3", // src slice overwrites dst slice
 				},
 				"newTopLevel": "newTopValue",
 			},


### PR DESCRIPTION
This pull request introduces an enhancement to the `mergeValues` function in Structuresmith, focusing on how it handles merging of nested structures, particularly slices. Previously, when merging two maps, slices within these maps were appended, which could lead to unintended duplication of data. With this update, slices in the source map now overwrite corresponding slices in the destination map, ensuring more predictable and clear outcomes when merging complex, nested configurations.

This change is crucial for scenarios where template configurations involve arrays or lists that require a clean slate rather than an accumulation of values. This PR includes updated unit tests to validate this new behavior, ensuring that it handles various complex structures, including deeply nested maps and slices.